### PR TITLE
Remove safe haskell

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghc: ["9.0.1", "8.10", "8.8", "8.6"]
+        ghc: ["9.2", "9.0", "8.10", "8.8", "8.6"]
     env:
       CONFIG: "--enable-tests --enable-benchmarks"
     steps:

--- a/src/Data/Connection.hs
+++ b/src/Data/Connection.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE Safe #-}
 {-# OPTIONS_HADDOCK show-extensions #-}
 
 -- |
@@ -16,60 +15,60 @@
 -- these are runnable as a standalone executable. See the /doctest/ stanza in the
 -- library's cabal file.
 module Data.Connection (
-   
+
     -- $example
-    
+
     Side(..),
-    
+
     -- * Types
 
     -- ** CastL
     castL,
     pattern CastL,
-    
+
     -- ** CastR
     castR,
     pattern CastR,
-    
+
     -- ** Cast
     cast,
     pattern Cast,
     Cast,
-    
+
     -- * Accessors
     midpoint,
     interval,
-    
+
     -- ** upper
     upper,
     upper1,
     upper2,
-    
+
     -- ** lower
     lower,
     lower1,
     lower2,
-    
+
     -- ** ceiling
     ceiling,
     ceiling1,
     ceiling2,
-   
+
     -- ** floor
     floor,
     floor1,
     floor2,
-   
+
     -- ** round
     round,
     round1,
     round2,
-    
+
     -- ** truncate
     truncate,
     truncate1,
     truncate2,
-    
+
     -- ** max/min
     maximize,
     minimize,
@@ -85,22 +84,22 @@ module Data.Connection (
     select,
     strong,
     divide,
-    
+
     -- * Extended
     extended,
     Extended (..),
 
 ) where
 
-import safe Data.Connection.Cast
-import safe Data.Connection.Class
-import safe Prelude hiding (ceiling, floor, round, truncate)
+import Data.Connection.Cast
+import Data.Connection.Class
+import Prelude hiding (ceiling, floor, round, truncate)
 
 {- $example
- 
+
  ==== What is a Galois connection?
 
- A [Galois connection](https://en.wikipedia.org/wiki/Galois_connection) is an 
+ A [Galois connection](https://en.wikipedia.org/wiki/Galois_connection) is an
  adjunction in the category of preorders: a pair of monotone maps /f :: p -> q/
  and /g :: q -> p/ between preorders /p/ and /q/, such that
 

--- a/src/Data/Connection/Cast.hs
+++ b/src/Data/Connection/Cast.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE Safe #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -73,13 +72,13 @@ module Data.Connection.Cast (
     Extended (..),
 ) where
 
-import safe Control.Arrow ((&&&))
-import safe Control.Category (Category, (<<<), (>>>))
-import safe qualified Control.Category as C
-import safe Data.Bifunctor (bimap)
-import safe Data.ExtendedReal
-import safe Data.Order
-import safe Prelude hiding (ceiling, floor, round, truncate)
+import Control.Arrow ((&&&))
+import Control.Category (Category, (<<<), (>>>))
+import qualified Control.Category as C
+import Data.Bifunctor (bimap)
+import Data.ExtendedReal
+import Data.Order
+import Prelude hiding (ceiling, floor, round, truncate)
 
 -- $setup
 -- >>> :set -XTypeApplications
@@ -103,7 +102,7 @@ import safe Prelude hiding (ceiling, floor, round, truncate)
 --  If a connection is existentialized over this value (i.e. has type /forall k. Cast k a b/) then it can
 --  provide either of two functions /f, h :: a -> b/.
 --
---  This is useful because it enables rounding, truncation, medians, etc. 
+--  This is useful because it enables rounding, truncation, medians, etc.
 --
 data Side = L | R
 

--- a/src/Data/Connection/Class.hs
+++ b/src/Data/Connection/Class.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE Safe #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -13,16 +12,16 @@ module Data.Connection.Class (
     Connection (..),
 ) where
 
-import safe Data.Connection.Cast
-import safe Data.Connection.Fixed
-import safe Data.Connection.Float
-import safe Data.Connection.Int
-import safe Data.Connection.Ratio
-import safe Data.Connection.Time
-import safe Data.Connection.Word
-import safe Data.Int
-import safe Data.Word
-import safe Numeric.Natural
+import Data.Connection.Cast
+import Data.Connection.Fixed
+import Data.Connection.Float
+import Data.Connection.Int
+import Data.Connection.Ratio
+import Data.Connection.Time
+import Data.Connection.Word
+import Data.Int
+import Data.Word
+import Numeric.Natural
 
 castL :: Connection 'L a b => Cast 'L a b
 castL = cast @'L

--- a/src/Data/Connection/Fixed.hs
+++ b/src/Data/Connection/Fixed.hs
@@ -2,10 +2,9 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE Safe #-}
 
 module Data.Connection.Fixed (
-    
+
     -- * Uni
     Uni,
     f00int,
@@ -59,15 +58,15 @@ module Data.Connection.Fixed (
     HasResolution (..),
 ) where
 
-import safe Data.Connection.Cast
-import safe Data.Connection.Float
-import safe Data.Connection.Ratio
-import safe Data.Fixed
-import safe Data.Order
-import safe Data.Order.Syntax
-import safe Data.Proxy
-import safe GHC.Real (Ratio (..), Rational)
-import safe Prelude hiding (Eq (..), Ord (..))
+import Data.Connection.Cast
+import Data.Connection.Float
+import Data.Connection.Ratio
+import Data.Fixed
+import Data.Order
+import Data.Order.Syntax
+import Data.Proxy
+import GHC.Real (Ratio (..), Rational)
+import Prelude hiding (Eq (..), Ord (..))
 
 -- | Shift by n 'units of least precision' where the ULP is determined by the precision.
 --

--- a/src/Data/Connection/Float.hs
+++ b/src/Data/Connection/Float.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE Safe #-}
 
 module Data.Connection.Float (
     -- * Float
@@ -46,18 +45,18 @@ module Data.Connection.Float (
     shift64,
 ) where
 
-import safe Data.Bool
-import safe Data.Connection.Cast hiding (ceiling, floor)
-import safe Data.Connection.Ratio
-import safe Data.Int
-import safe Data.Order
-import safe Data.Order.Syntax
-import safe Data.Ratio (approxRational)
-import safe Data.Word
-import safe GHC.Float as F
-import safe Numeric.Natural
-import safe Prelude hiding (Eq (..), Ord (..), until)
-import safe qualified Prelude as P
+import Data.Bool
+import Data.Connection.Cast hiding (ceiling, floor)
+import Data.Connection.Ratio
+import Data.Int
+import Data.Order
+import Data.Order.Syntax
+import Data.Ratio (approxRational)
+import Data.Word
+import GHC.Float as F
+import Numeric.Natural
+import Prelude hiding (Eq (..), Ord (..), until)
+import qualified Prelude as P
 
 ---------------------------------------------------------------------
 -- Float

--- a/src/Data/Connection/Int.hs
+++ b/src/Data/Connection/Int.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE Safe #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -46,9 +45,9 @@ module Data.Connection.Int (
     ixxint,
 ) where
 
-import safe Data.Connection.Cast
-import safe Data.Int
-import safe Data.Word
+import Data.Connection.Cast
+import Data.Int
+import Data.Word
 
 -- Int16
 w08i16 :: Cast k (Extended Word8) Int16
@@ -153,13 +152,13 @@ ixxint = extint
 
 {-# INLINE conn #-}
 conn :: forall a b k. (Bounded a, Bounded b, Integral a, Integral b) => Cast k (Extended a) b
-conn = Cast f g h 
+conn = Cast f g h
   where
     below = fromIntegral @a minBound - 1
     above = fromIntegral @a maxBound + 1
-    
+
     f = extended minBound above $ fromIntegral
-    
+
     g x | x <= below = NegInf
         | x >= above = PosInf
         | otherwise = Finite $ fromIntegral x
@@ -172,10 +171,9 @@ extint = CastL f $ maybe NegInf g
   where
     below = fromIntegral @a minBound - 1
     above = fromIntegral @a maxBound + 1
-    
+
     f = extended Nothing (Just above) (Just . fromIntegral)
-    
+
     g x | x <= below = NegInf
         | x >= above = PosInf
         | otherwise = Finite $ fromIntegral x
-

--- a/src/Data/Connection/Property.hs
+++ b/src/Data/Connection/Property.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE RankNTypes #-}
-{-# LANGUAGE Safe #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -41,10 +40,10 @@ module Data.Connection.Property (
     projective,
 ) where
 
-import safe Data.Connection.Cast
-import safe Data.Order
-import safe Data.Order.Property
-import safe Prelude hiding (Num (..), Ord (..), ceiling, floor)
+import Data.Connection.Cast
+import Data.Order
+import Data.Order.Property
+import Prelude hiding (Num (..), Ord (..), ceiling, floor)
 
 -- Adjointness
 

--- a/src/Data/Connection/Ratio.hs
+++ b/src/Data/Connection/Ratio.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
-{-# LANGUAGE Safe #-}
 
 module Data.Connection.Ratio (
     -- * Rational
@@ -24,15 +23,15 @@ module Data.Connection.Ratio (
     Ratio (..),
 ) where
 
-import safe Data.Bool
-import safe Data.Connection.Cast hiding (ceiling, floor, lower)
-import safe Data.Int
-import safe Data.Order
-import safe Data.Order.Syntax
-import safe Data.Word
-import safe GHC.Real (Ratio (..), Rational)
-import safe Numeric.Natural
-import safe Prelude hiding (Eq (..), Ord (..), until)
+import Data.Bool
+import Data.Connection.Cast hiding (ceiling, floor, lower)
+import Data.Int
+import Data.Order
+import Data.Order.Syntax
+import Data.Word
+import GHC.Real (Ratio (..), Rational)
+import Numeric.Natural
+import Prelude hiding (Eq (..), Ord (..), until)
 
 -- | A total version of 'GHC.Real.reduce'.
 reduce :: Integral a => Ratio a -> Ratio a

--- a/src/Data/Connection/Time.hs
+++ b/src/Data/Connection/Time.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE ConstraintKinds #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE Safe #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ViewPatterns #-}
@@ -17,13 +16,13 @@ module Data.Connection.Time (
     SystemTime (..),
 ) where
 
-import safe Data.Connection.Cast
-import safe Data.Connection.Fixed
-import safe Data.Connection.Float
-import safe Data.Int
-import safe Data.Order.Syntax
-import safe Data.Time.Clock.System
-import safe Prelude hiding (Eq (..), Ord (..), ceiling)
+import Data.Connection.Cast
+import Data.Connection.Fixed
+import Data.Connection.Float
+import Data.Int
+import Data.Order.Syntax
+import Data.Time.Clock.System
+import Prelude hiding (Eq (..), Ord (..), ceiling)
 
 -- $setup
 -- >>> :set -XTypeApplications

--- a/src/Data/Connection/Word.hs
+++ b/src/Data/Connection/Word.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE Safe #-}
+
 {-# LANGUAGE DataKinds #-}
 
 module Data.Connection.Word (
@@ -56,10 +56,10 @@ module Data.Connection.Word (
     intnat,
 ) where
 
-import safe Data.Connection.Cast
-import safe Data.Int
-import safe Data.Word
-import safe Numeric.Natural
+import Data.Connection.Cast
+import Data.Int
+import Data.Word
+import Numeric.Natural
 
 {-# INLINEABLE bndbin #-}
 bndbin :: (Eq a, Bounded a) => Cast k a Bool
@@ -68,7 +68,7 @@ bndbin = Cast f g h
     f i
         | i == minBound = False
         | otherwise = True
-    
+
     g x = if x then maxBound else minBound
 
     h i

--- a/src/Data/Lattice.hs
+++ b/src/Data/Lattice.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE Safe #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -60,24 +59,24 @@ module Data.Lattice (
     Boolean (..),
 ) where
 
-import safe Data.Bifunctor (bimap)
-import safe Data.Bool hiding (not)
-import safe Data.Connection.Cast
-import safe Data.Either
-import safe Data.Int
-import safe qualified Data.IntMap as IntMap
-import safe qualified Data.IntSet as IntSet
-import safe qualified Data.Map as Map
-import safe Data.Order
-import safe Data.Order.Syntax
-import safe qualified Data.Set as Set
-import safe Data.Word
-import safe Prelude hiding (Eq (..), Ord (..), ceiling, floor, not)
-import safe qualified Prelude as P
+import Data.Bifunctor (bimap)
+import Data.Bool hiding (not)
+import Data.Connection.Cast
+import Data.Either
+import Data.Int
+import qualified Data.IntMap as IntMap
+import qualified Data.IntSet as IntSet
+import qualified Data.Map as Map
+import Data.Order
+import Data.Order.Syntax
+import qualified Data.Set as Set
+import Data.Word
+import Prelude hiding (Eq (..), Ord (..), ceiling, floor, not)
+import qualified Prelude as P
 
--- >>> import safe Data.IntSet (IntSet,fromList)
+-- >>> import Data.IntSet (IntSet,fromList)
 -- >>> :load Data.Connection
--- >>> import safe Prelude hiding (round, floor, ceiling, truncate)
+-- >>> import Prelude hiding (round, floor, ceiling, truncate)
 
 -------------------------------------------------------------------------------
 -- Lattices

--- a/src/Data/Lattice/Property.hs
+++ b/src/Data/Lattice/Property.hs
@@ -1,15 +1,14 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE Safe #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 
 module Data.Lattice.Property where
 
-import safe Data.Lattice
-import safe Data.Order.Property
-import safe Data.Order.Syntax
-import safe Prelude hiding (Bounded, Eq (..), Ord (..), not)
+import Data.Lattice
+import Data.Order.Property
+import Data.Order.Syntax
+import Prelude hiding (Bounded, Eq (..), Ord (..), not)
 
 
 heyting0 :: Heyting a => a -> a -> a -> Bool
@@ -209,4 +208,3 @@ boolean5 x y = x \\ y == neg (neg y // neg x)
 
 boolean6 :: Biheyting a => a -> a -> Bool
 boolean6 x y = x // y == non (non y \\ non x)
-

--- a/src/Data/Order.hs
+++ b/src/Data/Order.hs
@@ -7,7 +7,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE PolyKinds #-}
-{-# LANGUAGE Safe #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeOperators #-}
@@ -31,30 +30,30 @@ module Data.Order (
     Down (..),
 ) where
 
-import safe Control.Applicative
-import safe Data.Bool
-import safe Data.Complex
-import safe Data.Either
-import safe qualified Data.Eq as Eq
-import safe Data.ExtendedReal
-import safe Data.Fixed
-import safe Data.Functor.Identity
-import safe Data.Int
-import safe qualified Data.IntMap as IntMap
-import safe qualified Data.IntSet as IntSet
-import safe Data.List.NonEmpty
-import safe qualified Data.Map as Map
-import safe Data.Maybe
-import safe Data.Ord (Down (..))
-import safe qualified Data.Ord as Ord
-import safe Data.Semigroup
-import safe qualified Data.Set as Set
-import safe Data.Time.Clock.System
-import safe Data.Void
-import safe Data.Word
-import safe GHC.Real
-import safe Numeric.Natural
-import safe Prelude hiding (Bounded, Ord (..), until)
+import Control.Applicative
+import Data.Bool
+import Data.Complex
+import Data.Either
+import qualified Data.Eq as Eq
+import Data.ExtendedReal
+import Data.Fixed
+import Data.Functor.Identity
+import Data.Int
+import qualified Data.IntMap as IntMap
+import qualified Data.IntSet as IntSet
+import Data.List.NonEmpty
+import qualified Data.Map as Map
+import Data.Maybe
+import Data.Ord (Down (..))
+import qualified Data.Ord as Ord
+import Data.Semigroup
+import qualified Data.Set as Set
+import Data.Time.Clock.System
+import Data.Void
+import Data.Word
+import GHC.Real
+import Numeric.Natural
+import Prelude hiding (Bounded, Ord (..), until)
 
 -- | An < https://en.wikipedia.org/wiki/Order_theory#Partially_ordered_sets order > on /a/.
 --

--- a/src/Data/Order/Interval.hs
+++ b/src/Data/Order/Interval.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE Safe #-}
 
 module Data.Order.Interval (
     Interval (),
@@ -11,11 +10,11 @@ module Data.Order.Interval (
     endpts,
 ) where
 
-import safe Data.Bifunctor (bimap)
-import safe qualified Data.Eq as Eq
-import safe Data.Order
-import safe Data.Order.Syntax
-import safe Prelude hiding (Bounded, Eq (..), Ord (..), until)
+import Data.Bifunctor (bimap)
+import qualified Data.Eq as Eq
+import Data.Order
+import Data.Order.Syntax
+import Prelude hiding (Bounded, Eq (..), Ord (..), until)
 
 ---------------------------------------------------------------------
 -- Intervals

--- a/src/Data/Order/Property.hs
+++ b/src/Data/Order/Property.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE Safe #-}
 
 -- | See <https://en.wikipedia.org/wiki/Binary_relation#Properties>.
 module Data.Order.Property (
@@ -51,10 +50,10 @@ module Data.Order.Property (
     antisymmetric,
 ) where
 
-import safe Data.Lattice hiding (not)
-import safe Data.Order
-import safe Data.Order.Syntax
-import safe Prelude hiding (Eq (..), Ord (..))
+import Data.Lattice hiding (not)
+import Data.Order
+import Data.Order.Syntax
+import Prelude hiding (Eq (..), Ord (..))
 
 -- | See <https://en.wikipedia.org/wiki/Binary_relation#Properties>.
 --

--- a/src/Data/Order/Syntax.hs
+++ b/src/Data/Order/Syntax.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE Safe #-}
 
 -- | Utilities for custom preludes and RebindableSyntax.
 module Data.Order.Syntax (
@@ -26,12 +25,12 @@ module Data.Order.Syntax (
     Ord.Ord (),
 ) where
 
-import safe Control.Exception
-import safe qualified Data.Eq as Eq
-import safe qualified Data.Ord as Ord
-import safe Data.Order
+import Control.Exception
+import qualified Data.Eq as Eq
+import qualified Data.Ord as Ord
+import Data.Order
 
-import safe Prelude hiding (Eq (..), Ord (..))
+import Prelude hiding (Eq (..), Ord (..))
 
 infix 4 <, >
 


### PR DESCRIPTION
DerivingVia is no longer safe Haskell https://downloads.haskell.org/~ghc/9.0.2/docs/html/users_guide/9.0.2-notes.html